### PR TITLE
Exception when shipping address undefined

### DIFF
--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -376,8 +376,8 @@ export default class PaymentRequest {
       shippingAddress: this._options.requestShipping ? this._shippingAddress : null,
       details: this._getPlatformDetails(details),
       shippingOption: IS_IOS ? this._shippingOption : null,
-      payerName: this._options.requestPayerName ? this._shippingAddress.recipient : null,
-      payerPhone: this._options.requestPayerPhone ? this._shippingAddress.phone : null,
+      payerName: this._shippingAddress && this._options.requestPayerName ? this._shippingAddress.recipient : null,
+      payerPhone: this._shippingAddress && this._options.requestPayerPhone ? this._shippingAddress.phone : null,
       payerEmail: IS_ANDROID && this._options.requestPayerEmail
         ? details.payerEmail
         : null


### PR DESCRIPTION
When user requests payer phone and name but not shipping, an
exception is thrown because shipping address is undefined. The
requested contact info comes through the shippingContact field on ios
with my other PR.