### PR TITLE
fix: pass paymentMethod in payment result

### DIFF
--- a/packages/react-native-payments/lib/ios/ReactNativePayments.m
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.m
@@ -408,7 +408,36 @@ RCT_EXPORT_METHOD(handleDetailsUpdate: (NSDictionary *)details
     if (token) {
         [paymentResponse setObject:token forKey:@"paymentToken"];
     }
+
+    if (payment.token.paymentMethod) {
+        PKPaymentMethod *method = payment.token.paymentMethod;
+        
+        NSString *paymentType = @"";
+        switch (method.type) {
+            case PKPaymentMethodTypeCredit:
+                paymentType = @"credit";
+                break;
+            case PKPaymentMethodTypeDebit:
+                paymentType = @"debit";
+                break;
+            case PKPaymentMethodTypePrepaid:
+                paymentType = @"prepaid";
+                break;
+            case PKPaymentMethodTypeStore:
+                paymentType = @"store";
+                break;
+            default:
+                break;
+        }
+        
+        paymentResponse[@"paymentMethod"] = @{
+                                              @"displayName": method.displayName ?: @"",
+                                              @"network": method.network ?: @"",
+                                              @"paymentType": paymentType
+                                            };
+    }
     
+
     if (payment.billingContact) {
         paymentResponse[@"billingContact"] = [self contactToString:payment.billingContact];
     }

--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -301,6 +301,7 @@ export default class PaymentRequest {
       billingContact: serializedBillingContact,
       shippingContact: serializedShippingContact,
       paymentToken,
+      paymentMethod,
       transactionIdentifier,
     } = details;
 
@@ -326,6 +327,7 @@ export default class PaymentRequest {
       billingContact,
       shippingContact,
       paymentToken,
+      paymentMethod,
       transactionIdentifier,
     };
   }

--- a/packages/react-native-payments/package.json
+++ b/packages/react-native-payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brandingbrand/react-native-payments",
-  "version": "0.9.1",
+  "version": "0.10.1",
   "scripts": {
     "run:packager": "cd examples/native && yarn run:packager",
     "run:ios": "cd examples/native && yarn run:ios",


### PR DESCRIPTION
Some clients require us to pass paymentMethod to finalize transaction. Updated the module to support this requirement