### PR TITLE
fix: Updates for react-native 0.60

### DIFF
--- a/packages/react-native-payments/ReactNativePayments.podspec
+++ b/packages/react-native-payments/ReactNativePayments.podspec
@@ -1,6 +1,6 @@
 require "json"
 
-package = JSON.parse(File.read(File.join(__dir__, "../../package.json")))
+package = JSON.parse(File.read(File.join(__dir__, "./package.json")))
 version = package["version"]
 giturl = package["repository"]
 
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.author       = "Naoufal Kadhom"
   s.platform     = :ios, "7.0"
   s.source       = { :git => giturl + ".git", :tag => version }
-  s.source_files  = "*.{h,m}"
+  s.source_files   = 'ios/*.{h,m}'
   s.requires_arc = true
 
 

--- a/packages/react-native-payments/index.d.ts
+++ b/packages/react-native-payments/index.d.ts
@@ -85,4 +85,7 @@ declare module '@brandingbrand/react-native-payments' {
     new(methodData: PaymentMethodData[], details: PaymentDetailsInit, options?: PaymentOptions): PaymentRequest;
   };
 
+  export declare var ApplePayButton: {
+    new(props: any);
+  }
 }


### PR DESCRIPTION
Moving the podspec to the root allows it to be autolinked and adding the ApplePayButton to the type file allows it to be imported.