### PR TITLE
feat: default PKPaymentButton to setup when no payment available

### DIFF
--- a/packages/react-native-payments/lib/ios/ReactNativePayments.m
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.m
@@ -27,6 +27,11 @@ RCT_EXPORT_METHOD(canMakePaymentsUsingNetworks:
     callback(@[[NSNull null], @([PKPaymentAuthorizationViewController canMakePaymentsUsingNetworks:paymentNetworks])]);
 }
 
+RCT_EXPORT_METHOD(availableNetworks: (RCTResponseSenderBlock)callback)
+{
+    callback(@[[NSNull null], [PKPaymentRequest availableNetworks]]);
+}
+
 RCT_EXPORT_METHOD(createPaymentRequest: (NSDictionary *)methodData
                   details: (NSDictionary *)details
                   options: (NSDictionary *)options

--- a/packages/react-native-payments/lib/js/NativePayments.js
+++ b/packages/react-native-payments/lib/js/NativePayments.js
@@ -16,6 +16,7 @@ const NativePayments: {
   show: () => Promise<any>,
   abort: () => Promise<any>,
   complete: PaymentComplete => Promise<any>,
+  availableNetworks: () => Promise<any>,
   getFullWalletAndroid: string => Promise<any>
 } = {
   supportedGateways: IS_ANDROID
@@ -149,6 +150,18 @@ const NativePayments: {
 
         resolve(true);
       });
+    });
+  },
+
+  availableNetworks() {
+    return new Promise((resolve) => {
+      if (IS_ANDROID) {
+        resolve(false);
+      }
+
+      ReactNativePayments.availableNetworks(
+        (err, data) => resolve(data)
+      );
     });
   },
 

--- a/packages/react-native-payments/lib/js/NativePayments.js
+++ b/packages/react-native-payments/lib/js/NativePayments.js
@@ -16,7 +16,7 @@ const NativePayments: {
   show: () => Promise<any>,
   abort: () => Promise<any>,
   complete: PaymentComplete => Promise<any>,
-  availableNetworks: () => Promise<any>,
+  availableNetworks: () => Promise<string[] | boolean>,
   getFullWalletAndroid: string => Promise<any>
 } = {
   supportedGateways: IS_ANDROID

--- a/packages/react-native-payments/lib/js/PKPaymentButton.js
+++ b/packages/react-native-payments/lib/js/PKPaymentButton.js
@@ -67,7 +67,7 @@ export class PKPaymentButton extends React.Component<Props> {
 
   render() {
     const { defaultToSetup } = this.state;
-    const buttonType = defaultToSetup ? 'setUp' : this.props.buttonType;
+    const buttonType = defaultToSetup ? 'setUp' : this.props.type;
     const onPress = defaultToSetup ? PaymentRequest.openPaymentSetup : this.props.onPress;
     return (
       <RNPKPaymentButton

--- a/packages/react-native-payments/lib/js/PKPaymentButton.js
+++ b/packages/react-native-payments/lib/js/PKPaymentButton.js
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { NativeModules, requireNativeComponent } from 'react-native';
+import PaymentRequest from './PaymentRequest';
 
 type PKPaymentButtonType =
   // A button with the Apple Pay logo only.
@@ -29,6 +30,7 @@ type Props = $Exact<{
   width?: number,
   height?: number,
   onPress: Function,
+  supportedNetworks?: string[]
 }>;
 
 const RNPKPaymentButton = requireNativeComponent('PKPaymentButton', null, {
@@ -46,12 +48,32 @@ export class PKPaymentButton extends React.Component<Props> {
     height: 44,
   };
 
+  state = {
+    defaultToSetup: false
+  }
+
+  async componentDidMount() {
+    const { supportedNetworks: customNetworks } = this.props;
+    let supportedNetworks = customNetworks;
+    if (supportedNetworks.length === 0) {
+      supportedNetworks = await PaymentRequest.availableNetworks();
+    }
+    const havePaymentSetup =
+      await PaymentRequest.canMakePaymentsUsingNetworks(supportedNetworks);
+    if (!havePaymentSetup) {
+      this.setState({ defaultToSetup: true })
+    }
+  }
+
   render() {
+    const { defaultToSetup } = this.state;
+    const buttonType = defaultToSetup ? 'setUp' : this.props.buttonType;
+    const onPress = defaultToSetup ? PaymentRequest.openPaymentSetup : this.props.onPress;
     return (
       <RNPKPaymentButton
         buttonStyle={this.props.style}
-        buttonType={this.props.type}
-        onPress={this.props.onPress}
+        buttonType={buttonType}
+        onPress={onPress}
         width={this.props.width}
         height={this.props.height}
       />

--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -499,5 +499,7 @@ export default class PaymentRequest {
   }
 
   static canMakePaymentsUsingNetworks = NativePayments.canMakePaymentsUsingNetworks;
+
+  static availableNetworks = NativePayments.availableNetworks;
 }
 


### PR DESCRIPTION
## Description
(iOS only) This defaults PKPaymentButton type to be “setUp” when no payment is available through the specified networks or Apple Pay available networks.