### PR TITLE
feat: Add maestro payment method

### DIFF
--- a/packages/react-native-payments/lib/ios/ReactNativePayments.m
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.m
@@ -250,6 +250,10 @@ RCT_EXPORT_METHOD(handleDetailsUpdate: (NSDictionary *)details
     if (iOSVersion >= 11) {
         [supportedNetworksMapping setObject:PKPaymentNetworkCarteBancaires forKey:@"cartebancaires"];
     }
+
+    if (iOSVersion >= 12) {
+        [supportedNetworksMapping setObject:PKPaymentNetworkMaestro forKey:@"maestro"];
+    }
     
     // Setup supportedNetworks
     NSArray *jsSupportedNetworks = methodData[@"supportedNetworks"];


### PR DESCRIPTION
**Notes:**
Apple Pay crashes because one of the supportedNetworks is maestro but cannot find it within react-native-payments. Added it to the .m file to make it work.