### PR TITLE
feat: pass in openPaymentSetup method

### DIFF
--- a/packages/react-native-payments/lib/ios/ReactNativePayments.m
+++ b/packages/react-native-payments/lib/ios/ReactNativePayments.m
@@ -90,6 +90,13 @@ RCT_EXPORT_METHOD(complete: (NSString *)paymentStatus
     callback(@[[NSNull null]]);
 }
 
+RCT_EXPORT_METHOD(openPaymentSetup: (RCTResponseSenderBlock)callback) {
+    PKPassLibrary* lib = [[PKPassLibrary alloc] init];
+    [lib openPaymentSetup];
+
+    callback(@[[NSNull null]]);
+}
+
 
 -(void) paymentAuthorizationViewControllerDidFinish:(PKPaymentAuthorizationViewController *)controller
 {

--- a/packages/react-native-payments/lib/js/NativePayments.js
+++ b/packages/react-native-payments/lib/js/NativePayments.js
@@ -16,6 +16,7 @@ const NativePayments: {
   show: () => Promise<any>,
   abort: () => Promise<any>,
   complete: PaymentComplete => Promise<any>,
+  openPaymentSetup: () => Promise<any>,
   getFullWalletAndroid: string => Promise<any>
 } = {
   supportedGateways: IS_ANDROID
@@ -145,6 +146,23 @@ const NativePayments: {
       }
 
       ReactNativePayments.complete(paymentStatus, err => {
+        if (err) return reject(err);
+
+        resolve(true);
+      });
+    });
+  },
+
+  openPaymentSetup() {
+    return new Promise((resolve, reject) => {
+      if (IS_ANDROID) {
+        // TODO
+        resolve(undefined);
+
+        return;
+      }
+
+      ReactNativePayments.openPaymentSetup(err => {
         if (err) return reject(err);
 
         resolve(true);

--- a/packages/react-native-payments/lib/js/PaymentRequest.js
+++ b/packages/react-native-payments/lib/js/PaymentRequest.js
@@ -499,5 +499,7 @@ export default class PaymentRequest {
   }
 
   static canMakePaymentsUsingNetworks = NativePayments.canMakePaymentsUsingNetworks;
+
+  static openPaymentSetup = NativePayments.openPaymentSetup;
 }
 


### PR DESCRIPTION
This passes in openPaymentSetup method in iOS which move users to the interface for adding credit cards. (the Wallet app on iPhone or to the Settings app on iPad). On devices that do not support Apple Pay, this method does nothing.

This takes over #17 